### PR TITLE
blog/nixos-home-router: fix hook for the nat prerouting chain

### DIFF
--- a/blog/nixos-home-router.md
+++ b/blog/nixos-home-router.md
@@ -242,7 +242,7 @@ networking = {
 
       table ip nat {
         chain prerouting {
-          type nat hook output priority filter; policy accept;
+          type nat hook prerouting priority filter; policy accept;
         }
 
         # Setup NAT masquerading on the ppp0 interface


### PR DESCRIPTION
Not sure if you accept corrections by pull request, but hey :-)

Thanks a lot for this article, I used it recently as documentation for migrating my own home router from iptables / networking.nat.* to nftables. I noted this error in the article which took me a few minutes to debug (in hindsight, it's fairly obvious...). Let's try to save some time for future readers!